### PR TITLE
Add @package to the docs

### DIFF
--- a/can-param.md
+++ b/can-param.md
@@ -1,5 +1,6 @@
 @module {function} can-param can-param
 @parent can-infrastructure
+@package ./package.json
 @description Serialize an object or array into a query string.
 
 @signature `param(object)`


### PR DESCRIPTION
This fixes an issue with the GitHub star and npm download buttons not appearing in the rendered canjs.com docs.