### PR TITLE
Clean up this repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,16 @@
 # Contributing to can-param
 
+Check out the [contribution guide on CanJS.com](https://canjs.com/doc/guides/contribute.html) for information on:
+
+- [Code of Conduct](https://canjs.com/doc/guides/contribute.html#CodeofConduct)
+- [Getting Help](https://canjs.com/doc/guides/contribute.html#GettingHelp)
+- [Project Organization](https://canjs.com/doc/guides/contributing/project-organization.html)
+- [Reporting Bugs](https://canjs.com/doc/guides/contributing/bug-report.html)
+- [Suggesting Features](https://canjs.com/doc/guides/contributing/feature-suggestion.html)
+- [Finding Ways to Contribute](https://canjs.com/doc/guides/contributing/finding-ways-to-contribute.html)
+
+The rest of this guide has information that’s specific to this repository.
+
 ## Developing Locally
 
 This section will walk you through setting up the [repository](https://github.com/canjs/can-param) on your computer.
@@ -71,15 +82,3 @@ npm run build
 ```
 
 This will create a `dist/` folder that contains the AMD, CommonJS, and global module versions of the project.
-
-### Building the documentation
-
-To generate the docs:
-
-```shell
-npm run document
-```
-
-This will create a `docs/` folder that contains a browsable site with all of your documentation.
-
-With the dev server running, you can view the docs at http://localhost:8080/docs/

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 CanJS
+Copyright (c) 2017 [Bitovi](https://www.bitovi.com/)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,50 +1,24 @@
 # can-param
 
-[![Build Status](https://travis-ci.org/canjs/can-param.png?branch=master)](https://travis-ci.org/canjs/can-param)
+[![Join the chat at https://gitter.im/canjs/canjs](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/canjs/canjs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/canjs/can-param/blob/master/LICENSE.md)
+[![npm version](https://badge.fury.io/js/can-param.svg)](https://www.npmjs.com/package/can-param)
+[![Travis build status](https://travis-ci.org/canjs/can-param.svg?branch=master)](https://travis-ci.org/canjs/can-param)
 
 Serialize an array or object into a query string.
 
-## Usage
+## Documentation
 
-### ES6 use
+Read the [API docs on CanJS.com](https://canjs.com/doc/can-param.html).
 
-With StealJS, you can import this module directly in a template that is autorendered:
+## Changelog
 
-```js
-import plugin from 'can-param';
-```
+See the [latest releases on GitHub](https://github.com/canjs/can-param/releases).
 
-### CommonJS use
+## Contributing
 
-Use `require` to load `can-param` and everything else
-needed to create a template that uses `can-param`:
+The [contribution guide](https://github.com/canjs/can-param/blob/master/CONTRIBUTING.md) has information on getting help, reporting bugs, developing locally, and more.
 
-```js
-var plugin = require("can-param");
-```
+## License
 
-## AMD use
-
-Configure the `can-param` package:
-
-```html
-<script src="require.js"></script>
-<script>
-	require.config({
-	    packages: [{
-		    	name: 'can-param',
-		    	location: 'node_modules/can-param/dist/amd',
-		    	main: 'lib/can-param'
-	    }]
-	});
-	require(["main-amd"], function(){});
-</script>
-```
-
-### Standalone use
-
-Load the `global` version of the plugin:
-
-```html
-<script src='./node_modules/can-param/dist/global/can-param.js'></script>
-```
+[MIT](https://github.com/canjs/can-param/blob/master/LICENSE.md)

--- a/can-param.md
+++ b/can-param.md
@@ -21,3 +21,12 @@ This is exported as `param` on [can-namespace].
 
 @param {Object} object An object or array.
 @return {String} The params formatted into a form-encoded string.
+
+@body
+
+## Try it
+
+Use this JS Bin to play around with this package:
+
+<a class="jsbin-embed" href="https://jsbin.com/zezamig/embed?js,console">can-param on jsbin.com</a>
+<script src="https://static.jsbin.com/js/embed.min.js?4.0.4"></script>


### PR DESCRIPTION
- Add a JS Bin embed to the main docs
- Link to the main docs from the README
- Standardize the badges used in the README
- Add links to the canjs.com contribution guide
- Fix the copyright holder in the license file
- Remove invalid “Building the documentation” section

Fixes https://github.com/canjs/can-param/issues/2