### PR TITLE
Encode objects within arrays to include indices

### DIFF
--- a/can-param-test.js
+++ b/can-param-test.js
@@ -12,7 +12,7 @@ QUnit.test("can-param", function(){
 		age: {
 			or: [ {lte: 5}, null ]
 		}
-	}), encodeURI("age[or][][lte]=5&age[or][]=null"));
+	}), encodeURI("age[or][0][lte]=5&age[or][1]=null"));
 
 	QUnit.deepEqual(param({
 		"undefined": undefined,
@@ -21,4 +21,18 @@ QUnit.test("can-param", function(){
 		"true": true,
 		"false": false
 	}),"undefined=undefined&null=null&NaN=NaN&true=true&false=false","true, false, undefined, etc");
+});
+
+QUnit.test("Encoding arrays of objects includes indices", function(){
+	var object = {items: [{name:'one'}, {name:'two'}]};
+	var out = param(object);
+
+	QUnit.equal(out, "items%5B0%5D%5Bname%5D=one&items%5B1%5D%5Bname%5D=two");
+});
+
+QUnit.test("Encoding array of primitives does not include indices", function() {
+	var object = {items: ['one', 'two']};
+	var out = param(object);
+
+	QUnit.equal(out, "items%5B%5D=one&items%5B%5D=two");
 });

--- a/can-param.js
+++ b/can-param.js
@@ -4,7 +4,10 @@ var namespace = require("can-namespace");
 function buildParam(prefix, obj, add) {
 	if (Array.isArray(obj)) {
 		for (var i = 0, l = obj.length; i < l; ++i) {
-			buildParam(prefix + '[]', obj[i], add);
+			var inner = obj[i];
+			var shouldIncludeIndex = typeof inner === 'object';
+			var arrayIndex = shouldIncludeIndex ? '[' + i + ']' : '[]';
+			buildParam(prefix + arrayIndex, inner, add);
 		}
 	} else if ( obj && typeof obj === "object" ) {
 		for (var name in obj) {


### PR DESCRIPTION
This makes it so that objects within arrays include the index.

```
{items: [{name:'one'}, {name:'two'}]}
```

becomes

```
items[0][name]=one&items[1][name]=two
``

Note that non-objects will not include the index. This is to match
jQuery's encoder.

```
{items: [{name:'one'}, {name:'two'}]}
```

Still becomes

```
items[]=one&items[]=two
```

Fixes #11